### PR TITLE
Allow to run PyPI-publish on workflow dispatch

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,6 +1,10 @@
 name: "Publish to PyPI"
 
 on:
+  # Allow to publish to PyPI on worklow dispatch. Be careful as we can not
+  # overwrite packages published to PyPI, so each run of this workflow needs
+  # to be accompanied by a version bump
+  workflow_dispatch:
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
This is useful when debugging changes to the installed package. However, note that we can't overwrite published packages, so each run of the workflow needs to be accompanied by a new code version tag.