### PR TITLE
Fix `docker compose ps --format "json"` output parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ running [Faasm](https://github.com/faasm/faasm) cluster.
 To install `faasmctl` you need a working `pip` (virtual-)environment. Then:
 
 ```bash
-pip install faasmctl==0.13.2
+pip install faasmctl==0.13.3
 ```
 
 ## Usage

--- a/faasmctl/util/version.py
+++ b/faasmctl/util/version.py
@@ -1,4 +1,4 @@
-FAASMCTL_VERSION = "0.13.2"
+FAASMCTL_VERSION = "0.13.3"
 
 
 def get_version():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "faasmctl"
-version = "0.13.2"
+version = "0.13.3"
 authors = [
   { name="Faasm Team", email="foo@bar.com" },
 ]


### PR DESCRIPTION
It took me a while to realize that the errors that I was seeing in `faasmctl` usage in Faasm's GHA scripts was due to a misaligment between my local version of `docker compose` (slightly out-of-date), and the one used in GHA's runners (`2.21.0`).

In particular, the last `docker compose` release includes a breaking change in the output of `docker compose ps --format "json"` that was making `faasmctl` fail. This is indicative of different things:
* The need of unit and integration tests in `faasmctl` (well-known issue).
* How different `compose` versions are now incompatible. Which means that if some GHA runners still have older versions of `compose` we are doomed.

To the last point, the reason why I was puzzled by this issue (and thought it was a race condition) is that it wouldn't _always_ happen, even though it has become much more frequent in the last 24 houts. So hopefully all GHA runners will have the latest compose version soon enough.